### PR TITLE
[SGE] fix: correctly using the qsub -cwd parameter.

### DIFF
--- a/examples/sge/src/main/scala/fr/iscpif/gridscale/example/sge/SubmitEcho.scala
+++ b/examples/sge/src/main/scala/fr/iscpif/gridscale/example/sge/SubmitEcho.scala
@@ -16,9 +16,10 @@
  */
 
 package fr.iscpif.gridscale.example.sge
+
 import fr.iscpif.gridscale._
 import fr.iscpif.gridscale.authentication._
-import fr.iscpif.gridscale.sge.{ SGEJobDescription, SGEJobService }
+import fr.iscpif.gridscale.sge.{SGEJobDescription, SGEJobService}
 import fr.iscpif.gridscale.ssh._
 
 object SubmitEcho extends App {
@@ -27,7 +28,7 @@ object SubmitEcho extends App {
 
   val description = new SGEJobDescription {
     def executable = "/bin/echo"
-    def arguments = "hello wold"
+    def arguments = "hello world"
     def workDirectory = service.home + "/testjob/"
   }
 

--- a/modules/gridscale-sge/src/main/scala/fr/iscpif/gridscale/sge/SGEJobDescription.scala
+++ b/modules/gridscale-sge/src/main/scala/fr/iscpif/gridscale/sge/SGEJobDescription.scala
@@ -45,7 +45,7 @@ trait SGEJobDescription extends JobDescription {
     queue.foreach(q ⇒ buffer += "#$ -q " + q)
     memory.foreach(m ⇒ buffer += "-l h_vmem=" + m + "M")
     wallTime.foreach(t ⇒ buffer += "-l h_cpu=" + t.toSeconds)
-    buffer += "#$ -cdw " + workDirectory
+    buffer += "#$ -cwd"
 
     buffer += executable + " " + arguments
 


### PR DESCRIPTION
Using the "cwd" parameter (as suggested at http://gridscheduler.sourceforge.net/htmlman/htmlman1/qsub.html), since the SGEJobService already changes the current work directory.

This supersedes #8, which was created by mistake from master.